### PR TITLE
Ti74 timing

### DIFF
--- a/src/hexbus.c
+++ b/src/hexbus.c
@@ -75,6 +75,7 @@ static void hex_send_nybble(uint8_t data, uint8_t hold) {
   hex_hsk_lo();
   hex_bav_hi();
   if(!hold) {
+    _delay_us(20);
     hex_release_bus_send();
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
 
     main.c: Main application
 */
-
+#include <stddef.h>
 #include <avr/interrupt.h>
 #include <util/delay.h>
 #include "config.h"


### PR DESCRIPTION
Added additional 20 usec delay  in hex_send_nybble to fix the program upload for the TI-74 which may be not  as fast as the CC-40.

Done experimentally without  deeper understanding of the hex-bus protocol, but it works without a single error since then on the TI-74.
Hope it does not damage the behavior when the CC-40 is connected.  