### PR TITLE
Format file size for catalog as bytes or kiB.

### DIFF
--- a/src/catalog.c
+++ b/src/catalog.c
@@ -8,6 +8,14 @@
 #include "uart.h"
 #include "catalog.h"
 
+// ------------------------ local functions --------------------------
+static const FILE_SIZE_WIDTH = 5; // width of file size format
+
+static int wild_cmp(const char *pattern, const char *string);
+static uint32_t number_of_digits(uint32_t num);
+static char* left_pad_with_blanks(char *buf, uint8_t width);
+static char* format_file_size(uint32_t bytes, char* buf, uint8_t width);
+
 // ------------------------- OLD/PGM catalog -------------------------
 
 //extern FATFS fs;  // from main.c
@@ -16,15 +24,16 @@ UCHAR   pgm_header[] = {0x80,0x03};
 //static const PROGMEM
 UCHAR   pgm_trailer[] = {0xff,0x7f,0x03,0x86,0x00,0x20, 0x00};
 
-static const uint8_t pgm_header_len = 4;  // number of bytes in pgm_header + 2 bytes for file length
-static const uint8_t pgm_trailer_len = 7; // number of bytes in the pgm_trailer
-static const uint8_t pgm_record_len = 33; // length record (constant here), includes len. of line number
-static const uint8_t pgm_line_len = 31;   // length of line, just the recordlen without len of line number (2 bytes)
-static const uint8_t pgm_str_len = 27;    // length of string without terminating zero
+// constants
+static const uint8_t PGM_HEADER_LEN = 4;  // number of bytes in pgm_header + 2 bytes for file length
+static const uint8_t PGM_TRAILER_LEN = 7; // number of bytes in the pgm_trailer
+static const uint8_t PGM_RECORD_LEN = 33; // length record (constant here), includes len. of line number
+static const uint8_t PGM_LINE_LEN = 31;   // length of line, just the recordlen without len of line number (2 bytes)
+static const uint8_t PGM_STR_LEN = 27;    // length of string without terminating zero
 
 // called once at the beginning
 void cat_open_pgm(uint16_t num_entries) {
-  uint16_t i = pgm_record_len * num_entries + pgm_header_len;
+  uint16_t i = PGM_RECORD_LEN * num_entries + PGM_HEADER_LEN;
   hex_putc(pgm_header[0],FALSE);
   hex_putc(pgm_header[1],FALSE);
   hex_putc(i & 255, FALSE);
@@ -42,24 +51,25 @@ void cat_close_pgm(void) {
 void cat_write_record_pgm(uint16_t lineno, uint32_t fsize, const char* filename, char attrib) {
 
 	uint8_t i;
-    char buf[5]; // needed for size_kb
-    char* size_kb = cat_bytes_to_kb(fsize, buf, sizeof(buf));
+	uint8_t width=FILE_SIZE_WIDTH;
+    char buf[width+1]; // needed for size_kb
+    char* file_size = format_file_size(fsize, buf, width);
 
     hex_puti(lineno, FALSE);                // line number, 2 bytes
-    hex_putc(pgm_line_len, FALSE);          // length of next "code" line (without len. of line number), 1 byte
+    hex_putc(PGM_LINE_LEN, FALSE);          // length of next "code" line (without len. of line number), 1 byte
     hex_putc(0xca, FALSE);                  // 0xca : token for unquoted string, next data is string, 1 byte
-    hex_putc(pgm_str_len, FALSE);           // length of the string without terminating zero, 1 byte
+    hex_putc(PGM_STR_LEN, FALSE);           // length of the string without terminating zero, 1 byte
     hex_putc('!', FALSE);                   // separator char line number / string 1 byte
-    for (i = 0; i < 4; i++) {               // file size in kilo bytes, 4 byte
-      hex_putc(size_kb[i], FALSE);          //
+    for (i = 0; i < width; i++) {               // file size in bytes or kiB, 5 bytes
+      hex_putc(file_size[i], FALSE);          //
     }                                       //
     hex_putc(' ', FALSE);                   // blank, 1 byte
     hex_putc('\"', FALSE);                  // quote, 1 byte
-    for(i = 0; i < 18 && i < strlen(filename) ; i++) {  // file name padded with trailing blanks, 18 bytes
+    for(i = 0; i < 17 && i < strlen(filename) ; i++) {  // file name padded with trailing blanks, 17 bytes
       hex_putc(filename[i], FALSE);
     }
     hex_putc('\"', FALSE);                  // quote, 1 byte
-    for( ; i < 18; i++) {
+    for( ; i < 17; i++) {
       hex_putc(' ', FALSE);
     }
     hex_putc(attrib, FALSE);                 // file attribute, 1 byte
@@ -68,32 +78,33 @@ void cat_write_record_pgm(uint16_t lineno, uint32_t fsize, const char* filename,
 }
 
 uint16_t cat_file_length_pgm(uint16_t num_entries) {
-  uint16_t len = num_entries * pgm_record_len + pgm_header_len + pgm_trailer_len;
+  uint16_t len = num_entries * PGM_RECORD_LEN + PGM_HEADER_LEN + PGM_TRAILER_LEN;
   return len;
 }
 
 // ------------------------- OPEN/INPUT catalog -------------------------
 
 uint16_t cat_max_file_length_txt(void) {
-  // 4 bytes for file size in kB plus
+  // 5 bytes for file size in bytes or kiB plus
   // 1 byte for "," separator plus
   // _MAX_LFN_LENGTH bytes max. for file name plus
   // 1 byte for "," separator plus
   // 1 byte for file attribute (F,D,V,..)
-  uint16_t len = 4 + 1 + _MAX_LFN_LENGTH + 1 + 1;
+  uint16_t len = FILE_SIZE_WIDTH + 1 + _MAX_LFN_LENGTH + 1 + 1;
   return len;
 }
 
 // Output looks like : 10.2,HELLO.PGM,F
 void cat_write_txt(uint16_t* dirnum, uint32_t fsize, const char* filename, char attrib) {
 	uint8_t i;
-    char buf[5];
-    char* size_kb = cat_bytes_to_kb(fsize, buf, sizeof(buf));
+	uint8_t width = FILE_SIZE_WIDTH;
+    char buf[width+1];
+    char* file_size = format_file_size(fsize, buf, width);
 
-	int len = strlen(size_kb) + 1 + strlen(filename) + 1 + 1; // length of data transmitted
+	int len = strlen(file_size) + 1 + strlen(filename) + 1 + 1; // length of data transmitted
 	hex_puti(len, FALSE);                                     // length
-	for(i = 0; i < strlen(size_kb)  ; i++) {                  // file size in kilo bytes, 4 byte
-	  hex_putc(size_kb[i], FALSE);                            //
+	for(i = 0; i < strlen(file_size)  ; i++) {                // file size in kilo bytes, 5 byte
+	  hex_putc(file_size[i], FALSE);                          //
 	}                                                         //
 	hex_putc(',', FALSE);                                     // "," separator, 1 byte
 	for(i = 0; i < strlen(filename); i++) {                   // file name , max. _MAX_LFN_LENGTH bytes
@@ -130,6 +141,7 @@ fno.lfn = lfn;
   return count;
 }
 
+// ----------------------------- local -----------------------------------
 // Return true if catalog entry shall be skipped.
 BOOL cat_skip_file(const char* filename, const char* pattern) {
 	BOOL skip = FALSE;
@@ -142,7 +154,8 @@ BOOL cat_skip_file(const char* filename, const char* pattern) {
 	return skip;
 }
 
-int wild_cmp(const char *pattern, const char *string)
+// Return true if string matches the pattern.
+static int wild_cmp(const char *pattern, const char *string)
 {
   if(*pattern=='\0' && *string=='\0') // Check if string is at end or not
 	  return 1;
@@ -157,34 +170,62 @@ int wild_cmp(const char *pattern, const char *string)
   return 0;
 }
 
-// Convert bytes to kBytes and format to ##.# . In case size >= 100kB returns 99.9.
-// TODO might make sense to send values < 1024 as actual bytes, since they will take the same number of chars...
-char* cat_bytes_to_kb(uint32_t bytes, char* buf, uint8_t len) {
-  int kb = bytes / 1024;
-  //int rb = (int)round(((bytes % 1024)/1024.0)*10);
-  int rb = (bytes % 1024)/(1024 / 10);
-  //if (rb == 10) { // bugfix
-  //  kb = kb + 1;
-  //  rb = 0;
-  //}
-  if (kb > 99) { // return 99.9 for files >= 100 kB
-    kb = 99;
-    rb = 9;
+// Return the number of digits of a decimal number.
+static uint32_t number_of_digits(uint32_t num) {
+  return  (num == 0) ? 1  : ((uint32_t)log10(num) + 1);
+}
+
+static char* left_pad_with_blanks(char *buf, uint8_t width) {
+  int shift = width - strlen(buf);
+  if (shift>0) {
+    memmove(&buf[shift], buf, strlen(buf)+1);
+    memset(buf,' ', shift);
   }
-  // next 11 lines replace snprintf
-  if (kb<9) {
-	  if (len>0) buf[0] =' ';
-	  if (len>1)  buf[1]=kb + '0';
-  }
-  else {
-	  if (len>0) buf[0]=kb/10 + '0';
-	  if (len>1) buf[1]=kb%10 + '0';
-  }
-  if (len>2) buf[2]='.';
-  if (len>3) buf[3]=rb + '0';
-  if (len>4) buf[4]=0;
-  //snprintf(buf, len, "%2d.%d", kb, rb); // costs 2k extra
   return buf;
 }
+
+/**
+ * Format the file size in bytes to an output of certain width.
+ * Returns a char* pointer to the formatted output.
+ * The working buffer buf must be at least of size width+1.
+ * If the file size number of digits is smaller or equal the given
+ * width, the output is in bytes, else the output is in kiB with an
+ * accuracy of 0.1 kiB. If the file size it too large to fit into the
+ * given width, a number of '?' is returned.
+ * Example : width=5
+              12345
+ * 100    -> "  100"    bytes
+ * 99999  -> "99999"    bytes
+ * 100000 -> " 97.6"    kiB
+ * 1023999-> "999.9"    kiB
+ * 1024000-> "?????"    with too small
+ */
+static char* format_file_size(uint32_t bytes, char* buf, uint8_t width) {
+  if (number_of_digits(bytes) <= width)  {
+    itoa(bytes,buf,10);
+    left_pad_with_blanks(buf, width);
+  }
+  else {
+    int kb = bytes / 1024;
+    if ( number_of_digits(kb)+2 <= width) {
+      int rb = (bytes % 1024)/(1024 / 10.0);
+      itoa(kb,buf,10);
+      int l=strlen(buf);
+      buf[l]='.';
+      itoa(rb,&buf[l+1],10);
+      left_pad_with_blanks(buf, width);
+    }
+    else {
+      memset(buf, '?', width);
+      buf[width]=0;
+    }
+  }
+  return buf;
+}
+
+
+
+
+
 
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -28,10 +28,5 @@ uint16_t cat_get_num_entries(FATFS* fsp, const char* directory, const char* patt
 // Return true if catalog entry shall be skipped.
 BOOL cat_skip_file(const char* filename, const char* pattern);
 
-// Return true if string matches the pattern.
-int wild_cmp(const char* pattern, const char* string);
-
-// Convert bytes to kBytes and format to ##.# . In case size >= 100kB returns 99.9.
-char* cat_bytes_to_kb(uint32_t bytes, char* buf, uint8_t len);
 
 #endif /* SRC_CATALOG_H_ */


### PR DESCRIPTION
Format the file size output on the catalog as bytes or kilobytes. The width of the field used for the file size was increased from 4 to 5 chars. The maximum file name length was shortened from 18 to 17 characters.
Output format:
- If the file size is smaller or equal then 99999 bytes it is printed as integer number of bytes. 
- If the size is larger then 99999 bytes it is printed in kilobytes as decimal number with one digit after the decimal point. 
- If the size is larger then 999.9 kiB five '?' are printed

Examples : 
 100          -> "  100"    bytes
99999       ->  "99999"    bytes
100000     ->  " 97.6"    kiB
1023999   ->  "999.9"    kiB
1024000   ->  "?????" 

Tried to make the format function such that one can easily change to 6 or more characters width.